### PR TITLE
escape requested task

### DIFF
--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsFromQueryWithAttributesRequest.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsFromQueryWithAttributesRequest.kt
@@ -58,7 +58,7 @@ class GetBuildsFromQueryWithAttributesRequest(private val repository: GradleEnte
                 continueCalls = false
                 progressFeedback.explicitUpdate(filter.maxBuilds)
             } else {
-                if(buildScans.size == previousBuildScansSize) {
+                if (buildScans.size == previousBuildScansSize) {
                     continueCalls = false
                     progressFeedback.explicitUpdate(filter.maxBuilds)
                 }

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsFromQueryWithAttributesRequest.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsFromQueryWithAttributesRequest.kt
@@ -34,6 +34,7 @@ class GetBuildsFromQueryWithAttributesRequest(private val repository: GradleEnte
         progressFeedback.init()
 
         var continueCalls = true
+        var previousBuildScansSize = 0
 
         while (buildScans.size < filter.maxBuilds && continueCalls) {
             val scans = if (buildScans.size == 0) {
@@ -52,12 +53,18 @@ class GetBuildsFromQueryWithAttributesRequest(private val repository: GradleEnte
             } else {
                 buildScans.addAll(scans)
             }
+
             if (buildScans.size < filter.maxBuilds && filter.maxBuilds <= 1000) {
                 continueCalls = false
                 progressFeedback.explicitUpdate(filter.maxBuilds)
             } else {
+                if(buildScans.size == previousBuildScansSize) {
+                    continueCalls = false
+                    progressFeedback.explicitUpdate(filter.maxBuilds)
+                }
                 progressFeedback.explicitUpdate(buildScans.size - 1)
             }
+            previousBuildScansSize = buildScans.size
         }
         logBuildScanInformation(buildScans, logger)
         return buildScans

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
@@ -27,7 +27,8 @@ class FilterBuildScanAdvancedSearch {
 
         var filterRequestedTasks = ""
         if (filter.requestedTask != null) {
-            filterRequestedTasks = "requested:${filter.requestedTask}"
+            val escapeColons = filter.requestedTask.toString().replace(":","\\:")
+            filterRequestedTasks = "requested:${escapeColons}"
         }
 
         var filterUser = ""

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
@@ -27,8 +27,8 @@ class FilterBuildScanAdvancedSearch {
 
         var filterRequestedTasks = ""
         if (filter.requestedTask != null) {
-            val escapeColons = filter.requestedTask.toString().replace(":","\\:")
-            filterRequestedTasks = "requested:${escapeColons}"
+            val escapeColons = filter.requestedTask.toString().replace(":", "\\:")
+            filterRequestedTasks = "requested:$escapeColons"
         }
 
         var filterUser = ""

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
@@ -43,6 +43,27 @@ class FilterBuildScanAdvancedSearchTest {
     }
 
     @Test
+    fun testEscapeTasksWithColons() {
+        val filter = Filter(
+            project = "myProject",
+            includeFailedBuilds = false,
+            tags = listOf("tag1", "tag2", "tag3"),
+            exclusiveTags = true,
+            requestedTask = ":app:compile",
+            user = "john_doe"
+        )
+
+        val filterBuildScan = FilterBuildScanAdvancedSearch()
+        val queryString = filterBuildScan.filter(filter)
+
+        val expectedQueryString =
+            "project:myProject%20(tag:tag1%20AND%20tag:tag2%20AND%20tag:tag3)%20buildOutcome:succeeded%20user:john_doe%20requested:\\:app\\:compile"
+
+        assertEquals(expectedQueryString, queryString)
+    }
+
+
+    @Test
     fun testFilterWithOnlyProject() {
         val filter = Filter(project = "myProject")
 

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
@@ -62,7 +62,6 @@ class FilterBuildScanAdvancedSearchTest {
         assertEquals(expectedQueryString, queryString)
     }
 
-
     @Test
     fun testFilterWithOnlyProject() {
         val filter = Filter(project = "myProject")


### PR DESCRIPTION
Fixing issues 0.2.1:
* Escape `:` in requested task
* Avoid infinite loop when the builds processed < max builds available