### PR TITLE
Support negation tags

### DIFF
--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
@@ -18,7 +18,7 @@ class FilterBuildScanAdvancedSearch {
         }
         var filterTagsValue = ""
         if (filter.tags.isNotEmpty()) {
-            filterTagsValue = if (filter.exclusiveTags) {
+            filterTagsValue = if (filter.exclusiveTags || filter.tags.any { it.contains("!") }) {
                 returnTagQuery(filter, "AND")
             } else {
                 returnTagQuery(filter, "OR")
@@ -66,7 +66,11 @@ class FilterBuildScanAdvancedSearch {
     private fun returnTagQuery(filter: Filter, operand: String): String {
         var tag = ""
         filter.tags.forEach {
-            tag += "tag:$it%20$operand%20"
+            if (it.contains("!")) {
+                tag += "-tag:${it.replaceFirst("!","")}%20$operand%20"
+            } else {
+                tag += "tag:$it%20$operand%20"
+            }
         }
         val last = tag.lastIndexOf("%20$operand%20")
         val filtered = tag.substring(0, last)

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/filter/FilterBuildScanAdvancedSearch.kt
@@ -18,7 +18,7 @@ class FilterBuildScanAdvancedSearch {
         }
         var filterTagsValue = ""
         if (filter.tags.isNotEmpty()) {
-            filterTagsValue = if (filter.exclusiveTags || filter.tags.any { it.contains("!") }) {
+            filterTagsValue = if (filter.exclusiveTags || filter.tags.any { it[0].toString() == "!" }) {
                 returnTagQuery(filter, "AND")
             } else {
                 returnTagQuery(filter, "OR")

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/parser/TagParser.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/parser/TagParser.kt
@@ -5,12 +5,22 @@ class TagParser {
         if (filterTags.isEmpty()) {
             return true
         }
-        if (exclusiveTags) {
+        val isExclusive = exclusiveTags || filterTags.any { it[0].toString() == "!" }
+        if (isExclusive) {
             val count = filterTags.size
             var aux = 0
-            buildTags.forEach {
-                if (filterTags.map { it.uppercase() }.contains(it.uppercase())) {
-                    aux++
+            filterTags.forEach {
+                if (it[0].toString() == "!") {
+                    val newTag = it.replaceFirst("!", "").uppercase()
+                    if (!buildTags.map { it.uppercase() }.contains(newTag)) {
+                        aux++
+                    }
+                } else {
+                    if (buildTags.map { it.uppercase() }
+                        .contains(it.uppercase())
+                    ) {
+                        aux++
+                    }
                 }
             }
             return count == aux

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
@@ -85,4 +85,40 @@ class FilterBuildScanAdvancedSearchTest {
 
         assertEquals(expectedQueryString, queryString)
     }
+
+    @Test
+    fun testFilterNegativeTags() {
+        val filter = Filter(exclusiveTags = true, tags = listOf("ci", "!main"))
+
+        val filterBuildScan = FilterBuildScanAdvancedSearch()
+        val queryString = filterBuildScan.filter(filter)
+
+        val expectedQueryString = "(tag:ci%20AND%20-tag:main)"
+
+        assertEquals(expectedQueryString, queryString)
+    }
+
+    @Test
+    fun testFilterNegativeTagsWithoutExclusiveTags() {
+        val filter = Filter(exclusiveTags = false, tags = listOf("ci", "!main"))
+
+        val filterBuildScan = FilterBuildScanAdvancedSearch()
+        val queryString = filterBuildScan.filter(filter)
+
+        val expectedQueryString = "(tag:ci%20AND%20-tag:main)"
+
+        assertEquals(expectedQueryString, queryString)
+    }
+
+    @Test
+    fun testFilterNegativeTagsOnlyStripsFirstCharacter() {
+        val filter = Filter(exclusiveTags = true, tags = listOf("ci", "!!main"))
+
+        val filterBuildScan = FilterBuildScanAdvancedSearch()
+        val queryString = filterBuildScan.filter(filter)
+
+        val expectedQueryString = "(tag:ci%20AND%20-tag:!main)"
+
+        assertEquals(expectedQueryString, queryString)
+    }
 }

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/FilterBuildScanAdvancedSearchTest.kt
@@ -121,4 +121,16 @@ class FilterBuildScanAdvancedSearchTest {
 
         assertEquals(expectedQueryString, queryString)
     }
+
+    @Test
+    fun testFilterNegativeTagsMoreThanOne() {
+        val filter = Filter(exclusiveTags = true, tags = listOf("ci", "!main", "!Dirty"))
+
+        val filterBuildScan = FilterBuildScanAdvancedSearch()
+        val queryString = filterBuildScan.filter(filter)
+
+        val expectedQueryString = "(tag:ci%20AND%20-tag:main%20AND%20-tag:Dirty)"
+
+        assertEquals(expectedQueryString, queryString)
+    }
 }

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/TagParserTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/TagParserTest.kt
@@ -20,6 +20,17 @@ class TagParserTest {
     }
 
     @Test
+    fun testTagIsIncluded_matchesOneTag_shouldReturnTrue() {
+        val filterTags = listOf("tag1")
+        val buildTags = listOf("tag1", "tag2")
+        val exclusiveTags = false
+
+        val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
+
+        assertEquals(true, result)
+    }
+
+    @Test
     fun testTagIsIncluded_withMatchingTagsAndExclusiveTags_shouldReturnTrue() {
         val filterTags = listOf("tag1", "tag2")
         val buildTags = listOf("tag1", "tag2")
@@ -64,10 +75,65 @@ class TagParserTest {
     }
 
     @Test
-    fun testTagIsIncluded_withNonMatchingTagsAndNonExclusiveTags_shouldReturnTrue() {
+    fun testTagIsIncluded_withNonMatchingTagsAndNonExclusiveTags_shouldReturnFalse() {
         val filterTags = listOf("tag1", "tag2")
         val buildTags = listOf("tag3")
         val exclusiveTags = false
+
+        val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun testTagIsIncluded_whenNegationIsNotPresent_shouldReturnTrue() {
+        val filterTags = listOf("!tag1")
+        val buildTags = listOf("tag3")
+        val exclusiveTags = false
+
+        val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun testTagIsIncluded_whenNegationIsPresent_shouldReturnFalse() {
+        val filterTags = listOf("!tag1")
+        val buildTags = listOf("tag1", "tag2", "tag3")
+        val exclusiveTags = false
+
+        val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun testTagIsIncluded_whenNegationIsPresentAndExclusive_shouldReturnFalse() {
+        val filterTags = listOf("!tag1")
+        val buildTags = listOf("tag1", "tag2", "tag3")
+        val exclusiveTags = true
+
+        val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun testTagIsIncluded_whenExistNegationButNotInTheFirstPlace_shouldReturnTrue() {
+        val filterTags = listOf("tag!1")
+        val buildTags = listOf("tag!1", "tag2", "tag3")
+        val exclusiveTags = true
+
+        val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun testTagIsIncluded_whenMoreThanOneNegativeTag_shouldReturnFalse() {
+        val filterTags = listOf("!tag1", "!tag2")
+        val buildTags = listOf("tag!1", "tag2", "tag3")
+        val exclusiveTags = true
 
         val result = tagParser.tagIsIncluded(filterTags, buildTags, exclusiveTags)
 


### PR DESCRIPTION
Support for negation tags. 
**Advanced query**
Adding `!` to the tag converts they query in exclusive tags search(-tag). 
A list of tags like: `listOf("ci", "!main", "!Dirty"))`
will return:
```
"(tag:ci%20AND%20-tag:main%20AND%20-tag:Dirty)"
```

**Old tag parser**
Same character to define negation tags `!`:
```
  val filterTags = listOf("!tag1")
  val buildTags = listOf("tag1", "tag2", "tag3")
```
will return false and convert the filter in exclusive tags

Closes https://github.com/cdsap/GEApiData/issues/7