### PR TITLE
fix: refactor scan metadata enrichment to clarify mapping boundary

### DIFF
--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.geapi.client.domain.impl
 
 import io.github.cdsap.geapi.client.domain.GetBuildsWithCachePerformance
 import io.github.cdsap.geapi.client.domain.impl.logger.Logger
+import io.github.cdsap.geapi.client.domain.impl.mapper.ScanMapper
 import io.github.cdsap.geapi.client.domain.impl.progress.ProgressFeedback
 import io.github.cdsap.geapi.client.model.Build
 import io.github.cdsap.geapi.client.model.Filter
@@ -37,6 +38,7 @@ class GetBuildsWithCachePerformanceRequest(private val repository: GradleEnterpr
         val duration = System.currentTimeMillis().toDuration(DurationUnit.MILLISECONDS)
         val progressFeedback = ProgressFeedback(filter.clientType, builds.size)
         val semaphore = Semaphore(filter.concurrentCallsConservative)
+        val scanMapper = ScanMapper()
 
         progressFeedback.init()
 
@@ -51,7 +53,7 @@ class GetBuildsWithCachePerformanceRequest(private val repository: GradleEnterpr
                             } else {
                                 repository.getBuildScanMavenCachePerformance(it.id)
                             }.apply {
-                                map(this, it)
+                                scanMapper.enrichBuildWithScanMetadata(this, it)
                             }
                         progressFeedback.update()
                         semaphore.release()
@@ -67,18 +69,5 @@ class GetBuildsWithCachePerformanceRequest(private val repository: GradleEnterpr
             ),
         )
         return cachePerformanceBuild
-    }
-
-    private fun map(
-        cachePerformance: Build,
-        scan: ScanWithAttributes,
-    ) {
-        cachePerformance.builtTool = scan.buildTool
-        cachePerformance.buildStartTime = scan.buildStartTime
-        cachePerformance.tags = scan.tags
-        cachePerformance.projectName = scan.projectName
-        cachePerformance.requestedTask = scan.requestedTasksGoals
-        cachePerformance.buildDuration = scan.buildDuration
-        cachePerformance.values = scan.values
     }
 }

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapper.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapper.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.geapi.client.domain.impl.mapper
 
+import io.github.cdsap.geapi.client.model.Build
 import io.github.cdsap.geapi.client.model.GradleScan
 import io.github.cdsap.geapi.client.model.MavenScan
 import io.github.cdsap.geapi.client.model.ScanWithAttributes
@@ -36,5 +37,18 @@ class ScanMapper {
                 values = mavenScan.values,
             )
         }
+    }
+
+    fun enrichBuildWithScanMetadata(
+        build: Build,
+        scan: ScanWithAttributes,
+    ) {
+        build.builtTool = scan.buildTool
+        build.buildStartTime = scan.buildStartTime
+        build.tags = scan.tags
+        build.projectName = scan.projectName
+        build.requestedTask = scan.requestedTasksGoals
+        build.buildDuration = scan.buildDuration
+        build.values = scan.values
     }
 }

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceTest.kt
@@ -54,6 +54,7 @@ class GetCachePerformanceImplTest {
             assert(result[0].tags.contains("tag3"))
             assertEquals(result[0].projectName, "AnotherProject")
             assert(result[0].requestedTask.contains("test"))
+            assertEquals(result[0].buildDuration, 1500)
             assertEquals(result[0].taskExecution.size, 2)
             assertEquals(result[0].values[0].name, "a")
             assertEquals(result[0].values[0].value, "b")
@@ -101,6 +102,7 @@ class GetCachePerformanceImplTest {
             assertEquals(result[0].projectName, "AnotherProject")
             assertEquals(result[0].projectName, "AnotherProject")
             assert(result[0].requestedTask.contains("test"))
+            assertEquals(result[0].buildDuration, 1500)
             assertEquals(result[0].values[0].name, "a")
 
             assertEquals(result[0].values[0].value, "b")

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapperTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapperTest.kt
@@ -1,0 +1,50 @@
+package io.github.cdsap.geapi.client.domain.impl.mapper
+
+import io.github.cdsap.geapi.client.model.AvoidanceSavingsSummary
+import io.github.cdsap.geapi.client.model.Build
+import io.github.cdsap.geapi.client.model.CustomValue
+import io.github.cdsap.geapi.client.model.Environment
+import io.github.cdsap.geapi.client.model.ScanWithAttributes
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ScanMapperTest {
+    @Test
+    fun enrichBuildWithScanMetadataCopiesScanAttributesOntoBuild() {
+        val build =
+            Build(
+                builtTool = "gradle",
+                taskExecution = emptyArray(),
+                id = "build-id",
+                buildDuration = 24,
+                avoidanceSavingsSummary = AvoidanceSavingsSummary("12", "1", "1"),
+                goalExecution = emptyArray(),
+            )
+        val scan =
+            ScanWithAttributes(
+                id = "scan-id",
+                projectName = "AnotherProject",
+                requestedTasksGoals = arrayOf("test"),
+                tags = arrayOf("tag3"),
+                hasFailed = true,
+                environment = Environment(username = "user2", numberOfCpuCores = "3"),
+                buildDuration = 1500,
+                buildTool = "maven",
+                buildStartTime = 1789,
+                values = arrayOf(CustomValue("a", "b")),
+            )
+
+        ScanMapper().enrichBuildWithScanMetadata(build, scan)
+
+        assertEquals("maven", build.builtTool)
+        assertEquals(1789, build.buildStartTime)
+        assertArrayEquals(arrayOf("tag3"), build.tags)
+        assertEquals("AnotherProject", build.projectName)
+        assertArrayEquals(arrayOf("test"), build.requestedTask)
+        assertEquals(1500, build.buildDuration)
+        assertEquals("a", build.values[0].name)
+        assertEquals("b", build.values[0].value)
+        assertEquals("build-id", build.id)
+    }
+}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/GEApiData#101: Refactor scan metadata enrichment to clarify mapping boundary

Fixes #101

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`