### PR TITLE
fix: add https://github.com/cdsap/build-process-watcher in the gha gradl

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,5 +23,11 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
 
+      - name: Build Process Watcher
+        uses: cdsap/build-process-watcher@v0.6.2
+        with:
+          remote_monitoring: 'true'
+          export_to_bigquery: 'true'
+
       - name: Run Tests
         run: ./gradlew test

--- a/src/test/kotlin/io/github/cdsap/geapi/BuildWorkflowTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/BuildWorkflowTest.kt
@@ -1,0 +1,34 @@
+package io.github.cdsap.geapi
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class BuildWorkflowTest {
+    @Test
+    fun buildWorkflow_includesBuildProcessWatcherBeforeGradleTests() {
+        val workflow = File(".github/workflows/build.yaml").readText()
+
+        assertTrue(
+            workflow.contains("uses: cdsap/build-process-watcher@v0.6.2"),
+            "Expected build-process-watcher action in GHA gradle build workflow",
+        )
+        assertTrue(
+            workflow.contains("remote_monitoring: 'true'"),
+            "Expected remote_monitoring enabled for build-process-watcher",
+        )
+        assertTrue(
+            workflow.contains("export_to_bigquery: 'true'"),
+            "Expected BigQuery export enabled for build-process-watcher",
+        )
+
+        val watcherIndex = workflow.indexOf("uses: cdsap/build-process-watcher@v0.6.2")
+        val gradleTestIndex = workflow.indexOf("run: ./gradlew test")
+        assertTrue(watcherIndex >= 0, "build-process-watcher step missing")
+        assertTrue(gradleTestIndex >= 0, "gradle test step missing")
+        assertTrue(
+            watcherIndex < gradleTestIndex,
+            "build-process-watcher must run before ./gradlew test",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Add https://github.com/cdsap/build-process-watcher in the GHA gradle builds

Fixes #103

## Changes

- `.github/workflows/build.yaml`
- `src/test/kotlin/io/github/cdsap/geapi/BuildWorkflowTest.kt`

## Verification

- `./gradlew test`
