### PR TITLE
fix: refactor cache performance mapping to clarify enrichment boundary

### DIFF
--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt
@@ -2,7 +2,7 @@ package io.github.cdsap.geapi.client.domain.impl
 
 import io.github.cdsap.geapi.client.domain.GetBuildsWithCachePerformance
 import io.github.cdsap.geapi.client.domain.impl.logger.Logger
-import io.github.cdsap.geapi.client.domain.impl.mapper.ScanMapper
+import io.github.cdsap.geapi.client.domain.impl.mapper.BuildCachePerformanceMapper
 import io.github.cdsap.geapi.client.domain.impl.progress.ProgressFeedback
 import io.github.cdsap.geapi.client.model.Build
 import io.github.cdsap.geapi.client.model.Filter
@@ -38,7 +38,7 @@ class GetBuildsWithCachePerformanceRequest(private val repository: GradleEnterpr
         val duration = System.currentTimeMillis().toDuration(DurationUnit.MILLISECONDS)
         val progressFeedback = ProgressFeedback(filter.clientType, builds.size)
         val semaphore = Semaphore(filter.concurrentCallsConservative)
-        val scanMapper = ScanMapper()
+        val buildCachePerformanceMapper = BuildCachePerformanceMapper()
 
         progressFeedback.init()
 
@@ -53,7 +53,7 @@ class GetBuildsWithCachePerformanceRequest(private val repository: GradleEnterpr
                             } else {
                                 repository.getBuildScanMavenCachePerformance(it.id)
                             }.apply {
-                                scanMapper.enrichBuildWithScanMetadata(this, it)
+                                buildCachePerformanceMapper.enrichBuildWithScanMetadata(this, it)
                             }
                         progressFeedback.update()
                         semaphore.release()

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/BuildCachePerformanceMapper.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/BuildCachePerformanceMapper.kt
@@ -1,0 +1,19 @@
+package io.github.cdsap.geapi.client.domain.impl.mapper
+
+import io.github.cdsap.geapi.client.model.Build
+import io.github.cdsap.geapi.client.model.ScanWithAttributes
+
+class BuildCachePerformanceMapper {
+    fun enrichBuildWithScanMetadata(
+        cachePerformance: Build,
+        scan: ScanWithAttributes,
+    ) {
+        cachePerformance.builtTool = scan.buildTool
+        cachePerformance.buildStartTime = scan.buildStartTime
+        cachePerformance.tags = scan.tags
+        cachePerformance.projectName = scan.projectName
+        cachePerformance.requestedTask = scan.requestedTasksGoals
+        cachePerformance.buildDuration = scan.buildDuration
+        cachePerformance.values = scan.values
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapper.kt
+++ b/src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapper.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.geapi.client.domain.impl.mapper
 
-import io.github.cdsap.geapi.client.model.Build
 import io.github.cdsap.geapi.client.model.GradleScan
 import io.github.cdsap.geapi.client.model.MavenScan
 import io.github.cdsap.geapi.client.model.ScanWithAttributes
@@ -37,18 +36,5 @@ class ScanMapper {
                 values = mavenScan.values,
             )
         }
-    }
-
-    fun enrichBuildWithScanMetadata(
-        build: Build,
-        scan: ScanWithAttributes,
-    ) {
-        build.builtTool = scan.buildTool
-        build.buildStartTime = scan.buildStartTime
-        build.tags = scan.tags
-        build.projectName = scan.projectName
-        build.requestedTask = scan.requestedTasksGoals
-        build.buildDuration = scan.buildDuration
-        build.values = scan.values
     }
 }

--- a/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/BuildCachePerformanceMapperTest.kt
+++ b/src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/BuildCachePerformanceMapperTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class ScanMapperTest {
+class BuildCachePerformanceMapperTest {
     @Test
     fun enrichBuildWithScanMetadataCopiesScanAttributesOntoBuild() {
         val build =
@@ -35,7 +35,7 @@ class ScanMapperTest {
                 values = arrayOf(CustomValue("a", "b")),
             )
 
-        ScanMapper().enrichBuildWithScanMetadata(build, scan)
+        BuildCachePerformanceMapper().enrichBuildWithScanMetadata(build, scan)
 
         assertEquals("maven", build.builtTool)
         assertEquals(1789, build.buildStartTime)


### PR DESCRIPTION
## Summary

### Problem

src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt:48-55 fetches cache performance from the repository and immediately mutates the returned Build with ScanWithAttributes data. The enrichment logic itself lives as a private map function at src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt:72-83, so orchestration, infrastructure access, and model mapping are all coupled in one use-case class.

### Why this matters

The current shape makes the request class harder to test in isolation and easy to duplicate when other derived build views need the same scan metadata. A small mapper boundary would keep the use case focused on coordinating repository calls while making the data-enrichment rule explicit and directly testable.

### Proposed change

Move the private Build enrichment logic into a small mapper under src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper, following the existing ScanMapper style. GetBuildsWithCachePerformanceRequest should call that mapper after repository retrieval and keep the same mutable Build behavior and output fields.

### Notes

DDD/clean architecture lens: this is a small boundary clarification. The use case remains responsible for coordinating the cache-performance query, while the translation from scan metadata into the returned domain model becomes a named mapping concern.

Fixes #105

## Changes

- `src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/GetBuildsWithCachePerformanceRequest.kt`
- `src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/BuildCachePerformanceMapper.kt`
- `src/main/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapper.kt`
- `src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/BuildCachePerformanceMapperTest.kt`
- `src/test/kotlin/io/github/cdsap/geapi/client/domain/impl/mapper/ScanMapperTest.kt`

## Verification

- `./gradlew test`
